### PR TITLE
Added animations to emote options

### DIFF
--- a/client/emotes.lua
+++ b/client/emotes.lua
@@ -2,3 +2,12 @@ RegisterNetEvent("emotes:client:doemote")
 AddEventHandler("emotes:client:doemote", function(emote)
 	Citizen.InvokeNative(0xB31A277C1AC7B7FF, PlayerPedId(), 0, 0, emote, 1, 1, 0, 0)
 end)
+
+-- emote from animation, doesn't have to be a dance
+RegisterNetEvent("emotes:client:dodance")
+AddEventHandler("emotes:client:dodance", function(dict,anim)
+    	local playerPed = PlayerPedId()
+    	local animDict = dict
+	RequestAnimDict(animDict)
+	Citizen.InvokeNative(0xEA47FE3719165B94, playerPed, animDict, anim, 8.0, -8.0, 9000, 1, 0, true, 0, false, 0, false)
+end)

--- a/server/emotes.lua
+++ b/server/emotes.lua
@@ -527,6 +527,18 @@ QRCore.Commands.Add("youstink", "does a you stink emote", {}, false, function(so
 	TriggerClientEvent('emotes:client:doemote', src, -166523388)
 end)
 
+-- dances from animations
+
+QRCore.Commands.Add("dance13", "does a lil dance", {}, false, function(source)
+	src = source
+	TriggerClientEvent('emotes:client:dodance', src, "script_mp@emotes@dance@carefree@a@male@unarmed@full", "fullbody")
+end)
+
+QRCore.Commands.Add("dance14", "does another lil dance", {}, false, function(source)
+	src = source
+	TriggerClientEvent('emotes:client:dodance', src, "script_mp@emotes@dance@carefree@b@male@unarmed@full", "fullbody")
+end)
+
 -- dance emotes
 --[[
 QRCore.Commands.Add("dance1", "does a dance awkward emote", {}, false, function(source)


### PR DESCRIPTION
Added in the ability to use animation dictionary with animation for an emote command instead of only an emote hash. Works with radial menu as well just as emotes do. 😸 (there may be a better way to format or do this, feel free to make pretty). Thnx Rex ! 