### PR TITLE
performance, handsup disarm, animal cleanup prevent insta-delete

### DIFF
--- a/client/handsup.lua
+++ b/client/handsup.lua
@@ -4,7 +4,9 @@ CreateThread(function()
     while true do
         Wait(7)
 
-        if IsControlJustPressed(0, RSGCore.Shared.Keybinds['X']) then
+        local keybind = RSGCore.Shared.Keybinds['X']
+
+        if IsControlJustPressed(0, keybind) then
             RSGCore.Functions.GetPlayerData(function(PlayerData)
                 if not PlayerData.metadata["isdead"]
                 and not IsEntityDead(cache.ped) -- unconditional death
@@ -13,6 +15,9 @@ CreateThread(function()
                     local animDict = "script_proc@robberies@homestead@lonnies_shack@deception"
 
                     if not IsEntityPlayingAnim(cache.ped, animDict, "hands_up_loop", 3) then
+                        SetCurrentPedWeapon(cache.ped, joaat('weapon_unarmed'))
+                        LocalPlayer.state:set("inv_busy", true, true)
+
                         if not HasAnimDictLoaded(animDict) then
                             RequestAnimDict(animDict)
                             while not HasAnimDictLoaded(animDict) do
@@ -24,6 +29,7 @@ CreateThread(function()
                         RequestAnimDict(animDict)
                     else
                         ClearPedSecondaryTask(cache.ped)
+                        LocalPlayer.state:set("inv_busy", false, true)
                     end
                 end
             end)

--- a/client/ignore.lua
+++ b/client/ignore.lua
@@ -1,12 +1,16 @@
 -- removes events and challenge notfications
 CreateThread(function()
+    local hashComplete = joaat('EVENT_CHALLENGE_GOAL_COMPLETE')
+    local hashReward = joaat('EVENT_CHALLENGE_REWARD')
+    local hashDaily = joaat('EVENT_DAILY_CHALLENGE_STREAK_COMPLETED')
+
     while true do
         Wait(10)
         local size = GetNumberOfEvents(0)
         if size > 0 then
             for i = 0, size - 1 do
                 local eventAtIndex = GetEventAtIndex(0, i)
-                if eventAtIndex == joaat('EVENT_CHALLENGE_GOAL_COMPLETE') or eventAtIndex == joaat('EVENT_CHALLENGE_REWARD') or eventAtIndex == joaat('EVENT_DAILY_CHALLENGE_STREAK_COMPLETED') then 
+                if eventAtIndex == hashComplete or eventAtIndex == hashReward or eventAtIndex == hashDaily then 
                     UiFeedClearAllChannels()
                 end
             end

--- a/client/latern.lua
+++ b/client/latern.lua
@@ -18,7 +18,7 @@ local davylantern = false
 
 CreateThread(function()
     while true do
-        Wait(0)
+        Wait(100)
         local heldweapon = Citizen.InvokeNative(0x8425C5F057012DAB, cache.ped)
 
         if heldweapon == -164645981 then

--- a/client/pointing.lua
+++ b/client/pointing.lua
@@ -2,17 +2,18 @@ local RSGCore = exports['rsg-core']:GetCoreObject()
 local pointing = false
 
 CreateThread(function()
+    local keybind = RSGCore.Shared.Keybinds['B']
     while true do
-        Wait(0)
+        Wait(7)
 
-        if IsControlPressed(0, RSGCore.Shared.Keybinds['B']) then
+        if IsControlPressed(0, keybind) then
             if not pointing then
                 pointing = true
                 RequestAnimDict('script_common@other@unapproved')
                 while not HasAnimDictLoaded('script_common@other@unapproved') do
                     Wait(100)
                 end
-                TaskPlayAnim(cache.ped, 'script_common@other@unapproved', 'loop_0', 1.0, -1.0, 9999999999, 30, 0, true, 0, false, 0, false)
+                TaskPlayAnim(cache.ped, 'script_common@other@unapproved', 'loop_0', 1.0, -1.0, -1, 30, 0, true, 0, false, 0, false)
             end
             Wait(500)
         else

--- a/client/smallfixes.lua
+++ b/client/smallfixes.lua
@@ -12,9 +12,10 @@ end)
 
 -- change voice proximity
 CreateThread(function()
+    local keybind = RSGCore.Shared.Keybinds['RIGHTBRACKET']
     while true do
-        Wait(0)
-        if IsControlJustPressed(0, RSGCore.Shared.Keybinds['RIGHTBRACKET']) then
+        Wait(7)
+        if IsControlJustPressed(0, keybind) then
             ExecuteCommand('cycleproximity')
         end
     end
@@ -56,7 +57,7 @@ end)
 -- pause menu animation
 CreateThread(function()
     while true do
-        Wait(0)
+        Wait(100)
 
         if IsPauseMenuActive() and not PauseOpen and Config.PauseReadBook then
             SetCurrentPedWeapon(cache.ped, 0xA2719263, true) -- set unarmed
@@ -110,24 +111,26 @@ CreateThread(function()
                 print(locale('cl_num_animal')..": " .. ped)
 
                 -- Check if the animal is attached to another entity
-                if IsEntityAttached(ped) then
+                if IsEntityAttachedToAnyPed(ped) then
                     -- Mark the animal as picked up
                     pickedUpAnimals[ped] = true
                     print(locale('cl_num_animal_b')..": " .. ped)
                 elseif not pickedUpAnimals[ped] then
                     -- Check if the entity still exists
                     if DoesEntityExist(ped) then
-                        -- Try to delete the entity
-                        DeleteEntity(ped)
+                        if GetPedTimeOfDeath(ped) < GetGameTimer() then --check if dead long enough
+                            -- Try to delete the entity
+                            DeleteEntity(ped)
 
-                        -- Check if deletion was successful
-                        if DoesEntityExist(ped) then
-                            print(locale('cl_num_animal_c')..": " .. ped)
-                            SetEntityAsNoLongerNeeded(ped)
-                            SetEntityHealth(ped, 0)
-                        else
-                            print(locale('cl_num_animal_d')..": " .. ped)
-                            deadAnimalsCount = deadAnimalsCount + 1
+                            -- Check if deletion was successful
+                            if DoesEntityExist(ped) then
+                                print(locale('cl_num_animal_c')..": " .. ped)
+                                SetEntityAsNoLongerNeeded(ped)
+                                SetEntityHealth(ped, 0)
+                            else
+                                print(locale('cl_num_animal_d')..": " .. ped)
+                                deadAnimalsCount = deadAnimalsCount + 1
+                            end
                         end
                     else
                         print(locale('cl_num_animal_e')..": " .. ped)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -3,7 +3,7 @@ rdr3_warning 'I acknowledge that this is a prerelease build of RedM, and I am aw
 game 'rdr3'
 
 description 'rsg-essentials'
-version '2.3.3'
+version '2.3.4'
 
 shared_scripts {
     '@ox_lib/init.lua',

--- a/server/xmas.lua
+++ b/server/xmas.lua
@@ -1,6 +1,6 @@
-CreateThread(function()
-    Wait(0)
-    if Config.EnableXmas == true then
+if Config.EnableXmas == true then
+    CreateThread(function()
+        Wait(0)
         exports.weathersync:setWeatherPattern({
             ['snowlight'] = {
                 ['snow'] = 20,
@@ -30,8 +30,8 @@ CreateThread(function()
             }
         })
         exports.weathersync:setWeather('snowlight', 10.0, false, true)
-    end
-end)
+    end)
+end
 
 AddEventHandler('onResourceStop', function(resource)
     if GetCurrentResourceName() ~= resource then


### PR DESCRIPTION
- optimized loops
    - performance heavier operations are executed only when necessary
    - increased wait times where possible
- hands up (X) will disarm and block inventory
- animal cleanup will delete animals attached to wagons (dead horses)
- animal cleanup will delete animals that are dead for +-2 minutes
    - `GetPedTimeOfDeath` native sets time in +-2 minutes in future, so we use it as failsafe to prevent animals just shot to disappear